### PR TITLE
Support for printing to console

### DIFF
--- a/include/kernel/syscall.h
+++ b/include/kernel/syscall.h
@@ -2,8 +2,9 @@
 #define KERNEL_SYSCALL_H
 
 enum {
-	SYS_exit	= 1,
-	SYS_wait	= 2,
+	SYS_exit		= 1,
+	SYS_wait		= 2,
+	SYS_console_print	= 3,
 };
 
 int syscall(int nr, ...);

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -19,6 +19,14 @@ static int sys_wait(void)
 	return 0;
 }
 
+static int sys_console_print(const char *text)
+{
+	/* FIXME: This is unsafe -- we are following a pointer from
+	   userspace without verifying it.  */
+	puts(text);
+	return 0;
+}
+
 #define SYSCALL0(fn)                                                                                                   \
 	case (SYS_##fn):                                                                                               \
 		do {                                                                                                   \
@@ -41,6 +49,7 @@ int syscall(int nr, ...)
 	switch (nr) {
 	SYSCALL1(exit, int);
 	SYSCALL0(wait);
+	SYSCALL1(console_print, const char *);
 	}
 	return -ENOSYS;
 }

--- a/usr/libmanticore/CMakeLists.txt
+++ b/usr/libmanticore/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(manticore
     src/syscall.c
     src/syscalls/exit.c
     src/syscalls/wait.c
+    src/syscalls/console_print.c
 )
 
 target_include_directories(manticore PUBLIC

--- a/usr/libmanticore/include/manticore/syscalls.h
+++ b/usr/libmanticore/include/manticore/syscalls.h
@@ -2,12 +2,14 @@
 #define MANTICORE_SYSCALLS_H
 
 enum {
-	SYS_exit	= 1,
-	SYS_wait	= 2,
+	SYS_exit		= 1,
+	SYS_wait		= 2,
+	SYS_console_print	= 3,
 };
 
 void exit(int status) __attribute__ ((noreturn));
 void wait(void);
+void console_print(const char *text);
 
 long syscall0(long number);
 long syscall1(long number, long arg0);

--- a/usr/libmanticore/src/syscalls/console_print.c
+++ b/usr/libmanticore/src/syscalls/console_print.c
@@ -1,0 +1,6 @@
+#include <manticore/syscalls.h>
+
+void console_print(const char *text)
+{
+	syscall1(SYS_console_print, (unsigned long) text);
+}


### PR DESCRIPTION
This pull request adds an *unsafe* `console_print()` system call for debugging user space processes.