### PR TITLE
Build support for Arch Linux and Antergos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ tests += tests/tst-printf.o
 endif
 
 WARNINGS = -Wall -Wextra -Wno-unused-parameter
-CFLAGS += -std=gnu11 -O3 -g $(WARNINGS) -ffreestanding $(includes) -fno-pie
+CFLAGS += -std=gnu11 -O3 -g $(WARNINGS) -ffreestanding $(includes) -fno-pie -fno-stack-protector
 ASFLAGS += -D__ASSEMBLY__ $(includes)
 LDFLAGS += --gc-sections
 

--- a/scripts/install-toolchain
+++ b/scripts/install-toolchain
@@ -8,6 +8,8 @@ if [ "$ID" = "fedora" ]; then
     sudo dnf install gcc xorriso
 elif [ "$ID" = "ubuntu" ]; then
     sudo apt install --yes curl grub-pc-bin cmake
+elif [ "$ID" = "antergos" ] || [ "$ID" = "arch" ]; then
+    sudo pacman -S --noconfirm curl cmake grub mtools
 else
     echo "Warning: '$ID' is not a supported OS."
 fi

--- a/scripts/install-toolchain
+++ b/scripts/install-toolchain
@@ -25,4 +25,4 @@ rustup install $toolchain
 rustup default $toolchain
 rustup component add rust-src
 
-cargo install xargo
+cargo install --force xargo


### PR DESCRIPTION
Using the OS ID's `antergos` and `arch` as discriminators for installing dependencies with `pacman`.