### PR TITLE
Fix unsafe console_print() system call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ objs += kernel/panic.o
 objs += kernel/printf.o
 objs += kernel/syscall.o
 objs += kernel/thread.o
+objs += kernel/user-copy.o
 objs += mm/kmem.o
 
 rust_src += drivers/pci/lib.rs

--- a/arch/x86_64/Makefile
+++ b/arch/x86_64/Makefile
@@ -19,8 +19,9 @@ objs += arch/x86_64/multiboot_header.o
 objs += arch/x86_64/pci.o
 objs += arch/x86_64/setup.o
 objs += arch/x86_64/syscall.o
-objs += arch/x86_64/thread.o
 objs += arch/x86_64/task.o
+objs += arch/x86_64/thread.o
+objs += arch/x86_64/user-copy.o
 objs += drivers/uart/8250.o
 
 all: kernel.iso

--- a/arch/x86_64/exceptions.c
+++ b/arch/x86_64/exceptions.c
@@ -1,5 +1,6 @@
 #include <arch/exceptions.h>
 
+#include <kernel/page-fault.h>
 #include <kernel/printf.h>
 #include <kernel/panic.h>
 #include <kernel/irq.h>
@@ -8,6 +9,7 @@
 #include <arch/interrupt-defs.h>
 #include <arch/segment.h>
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -238,6 +240,11 @@ void do_x86_general_protection_exception(struct exception_frame *ef)
 
 void do_x86_page_fault_exception(struct exception_frame *ef)
 {
+	void *fixup = page_fault_get_fixup();
+	if (fixup) {
+		ef->rip = (uint64_t) fixup;
+		return;
+	}
 	uint64_t addr = x86_read_cr2();
 	printf("Page fault at address %016lx\n", addr);
 	dump_exception_frame(ef);

--- a/arch/x86_64/user-copy.S
+++ b/arch/x86_64/user-copy.S
@@ -1,0 +1,27 @@
+#include <kernel/errno.h>
+
+.align 16
+raw_copy_from_user_fixup:
+	xorq	%rdi, %rdi
+	callq	page_fault_set_fixup
+
+	movq	$-EFAULT, %rax
+	retq
+
+.align 16
+.globl raw_copy_from_user
+.type raw_copy_from_user, @function
+raw_copy_from_user:
+	push	%rdi
+	movq	$raw_copy_from_user_fixup, %rdi
+	callq	page_fault_set_fixup
+	pop	%rdi
+
+	movq	%rdx, %rcx
+	rep movsb
+
+	xorq	%rdi, %rdi
+	callq	page_fault_set_fixup
+
+	xorq	%rax, %rax
+	retq

--- a/drivers/uart/8250.c
+++ b/drivers/uart/8250.c
@@ -38,9 +38,16 @@ void console_write_char(char ch)
 	uart_8250_write_char(ch);
 }
 
-void console_write(const char *s)
+void console_write_str(const char *s)
 {
 	while (*s) {
+		uart_8250_write_char(*s++);
+	}
+}
+
+void console_write(const char *s, size_t count)
+{
+	while (count--) {
 		uart_8250_write_char(*s++);
 	}
 }

--- a/include/kernel/console.h
+++ b/include/kernel/console.h
@@ -1,8 +1,11 @@
 #ifndef KERNEL_CONSOLE_H
 #define KERNEL_CONSOLE_H
 
+#include <stddef.h>
+
 void console_init(void);
 void console_write_char(char ch);
-void console_write(const char *s);
+void console_write_str(const char *s);
+void console_write(const char *s, size_t count);
 
 #endif

--- a/include/kernel/errno.h
+++ b/include/kernel/errno.h
@@ -2,6 +2,7 @@
 #define KERNEL_ERRNO_H 1
 
 #define ENOMEM 12
+#define EFAULT 14
 #define EINVAL 22
 #define ENOSYS 38
 

--- a/include/kernel/page-fault.h
+++ b/include/kernel/page-fault.h
@@ -1,0 +1,7 @@
+#ifndef KERNEL_PAGE_FAULT_H
+#define KERNEL_PAGE_FAULTH
+
+void page_fault_set_fixup(void *);
+void *page_fault_get_fixup(void);
+
+#endif

--- a/include/kernel/syscall.h
+++ b/include/kernel/syscall.h
@@ -7,6 +7,6 @@ enum {
 	SYS_console_print	= 3,
 };
 
-int syscall(int nr, ...);
+long syscall(int nr, ...);
 
 #endif

--- a/include/kernel/types.h
+++ b/include/kernel/types.h
@@ -1,0 +1,6 @@
+#ifndef KERNEL_TYPES_H
+#define KERNEL_TYPES_H
+
+typedef long ssize_t;
+
+#endif

--- a/include/kernel/user-access.h
+++ b/include/kernel/user-access.h
@@ -1,0 +1,15 @@
+//
+// Userspace access functions (i.e. data copies between kernel and userspace).
+//
+#ifndef KERNEL_USER_ACCESS_H
+#define KERNEL_USER_ACCESS_H
+
+#include <stddef.h>
+
+// TODO: userspace pointer annotation
+#define __user
+
+/// Copy memory region from userspace to a kernel buffer.
+int copy_from_user(void *dest, const void __user *src, size_t len);
+
+#endif

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -8,9 +8,9 @@
 
 static void do_panic(char *msg)
 {
-	console_write("Kernel panic: ");
-	console_write(msg);
-	console_write("\n");
+	console_write_str("Kernel panic: ");
+	console_write_str(msg);
+	console_write_str("\n");
 	arch_local_interrupt_disable();
 	for (;;) {
 		arch_halt_cpu();

--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -266,7 +266,7 @@ int putchar(int c)
 
 int puts(const char *s)
 {
-	console_write(s);
+	console_write_str(s);
 	return 1;
 }
 

--- a/kernel/process.rs
+++ b/kernel/process.rs
@@ -1,7 +1,7 @@
 use alloc::rc::Rc;
 use core::intrinsics::transmute;
 use core::slice;
-use core::cell::RefCell;
+use core::cell::{Cell, RefCell};
 use intrusive_collections::LinkedListLink;
 use memory;
 use mmu;
@@ -25,6 +25,7 @@ pub struct Process {
     pub state: RefCell<ProcessState>,
     pub task_state: TaskState,
     pub vmspace: VMAddressSpace,
+    pub page_fault_fixup: Cell<u64>,
     pub link: LinkedListLink,
 }
 
@@ -36,6 +37,7 @@ impl Process {
             state: RefCell::new(ProcessState::RUNNABLE),
             task_state: task_state,
             vmspace: vmspace,
+            page_fault_fixup: Cell::new(0),
             link: LinkedListLink::new(),
         }
     }

--- a/kernel/sched.rs
+++ b/kernel/sched.rs
@@ -96,6 +96,28 @@ pub extern "C" fn process_wait() {
 }
 
 #[no_mangle]
+pub extern fn page_fault_set_fixup(fixup: u64)
+{
+    unsafe {
+        if let Some(ref mut current) = CURRENT {
+            current.page_fault_fixup.replace(fixup);
+        }
+    }
+}
+
+#[no_mangle]
+pub extern fn page_fault_get_fixup() -> u64
+{
+    unsafe {
+        if let Some(ref mut current) = CURRENT {
+            return current.page_fault_fixup.get()
+        } else {
+            return 0
+        }
+    }
+}
+
+#[no_mangle]
 pub extern "C" fn wake_up_processes() {
     loop {
         unsafe {

--- a/kernel/user-copy.c
+++ b/kernel/user-copy.c
@@ -1,0 +1,17 @@
+#include <kernel/user-access.h>
+
+#include <kernel/errno.h>
+
+#include <arch/vmem.h>
+
+int raw_copy_from_user(void *dest, const void __user *src, size_t len);
+
+int copy_from_user(void *dest, const void __user *src, size_t len)
+{
+	/* FIXME: Make this check more strict by looking at process virtual
+		  memory limits.  */
+	if ((unsigned long)src >= (unsigned long)KERNEL_VMA) {
+		return -EFAULT;
+	}
+	return raw_copy_from_user(dest, src, len);
+}

--- a/usr/CMakeLists.txt
+++ b/usr/CMakeLists.txt
@@ -4,3 +4,4 @@ project(manticore LANGUAGES C)
 
 add_subdirectory(libmanticore)
 add_subdirectory(liblinux)
+add_subdirectory(tests)

--- a/usr/liblinux/include/assert.h
+++ b/usr/liblinux/include/assert.h
@@ -1,0 +1,15 @@
+#ifndef _ASSERT_H
+#define _ASSERT_H
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#define assert(expr)                                                                                                   \
+	do {                                                                                                           \
+		if (!(expr)) {                                                                                         \
+			fprintf(stderr, "%s:%d: %s: Assertion `" #expr "' failed.\n", __FILE__, __LINE__, __func__);   \
+			exit(1);                                                                                       \
+		}                                                                                                      \
+	} while (0)
+
+#endif

--- a/usr/liblinux/include/errno.h
+++ b/usr/liblinux/include/errno.h
@@ -2,6 +2,7 @@
 #define _ERRNO_H
 
 #define EBADF 9
+#define EFAULT 14
 #define EINVAL 22
 #define EMFILE 24
 

--- a/usr/liblinux/src/stdio.c
+++ b/usr/liblinux/src/stdio.c
@@ -298,7 +298,7 @@ int fprintf(FILE *stream, const char *fmt, ...)
 	int ret = vsprintf(text, fmt, ap);
 	va_end(ap);
 
-	console_print(text);
+	console_print(text, ret);
 
 	return 0; // FIXME
 }

--- a/usr/libmanticore/include/manticore/syscalls.h
+++ b/usr/libmanticore/include/manticore/syscalls.h
@@ -1,6 +1,10 @@
 #ifndef MANTICORE_SYSCALLS_H
 #define MANTICORE_SYSCALLS_H
 
+#include <manticore/types.h>
+
+#include <stddef.h>
+
 enum {
 	SYS_exit		= 1,
 	SYS_wait		= 2,
@@ -9,9 +13,10 @@ enum {
 
 void exit(int status) __attribute__ ((noreturn));
 void wait(void);
-void console_print(const char *text);
+ssize_t console_print(const char *text, size_t count);
 
 long syscall0(long number);
 long syscall1(long number, long arg0);
+long syscall2(long number, long arg0, long arg1);
 
 #endif

--- a/usr/libmanticore/include/manticore/types.h
+++ b/usr/libmanticore/include/manticore/types.h
@@ -1,0 +1,6 @@
+#ifndef MANTICORE_TYPES_H
+#define MANTICORE_TYPES_H
+
+typedef long ssize_t;
+
+#endif

--- a/usr/libmanticore/src/syscall.c
+++ b/usr/libmanticore/src/syscall.c
@@ -21,3 +21,14 @@ long syscall1(long number, long arg0)
 		: "rcx", "r11", "memory");
         return ret;
 }
+
+long syscall2(long number, long arg0, long arg1)
+{
+        unsigned long ret;
+        asm volatile(
+		"syscall"
+		: "=a"(ret)
+		: "a"(number), "D"(arg0), "S"(arg1)
+		: "rcx", "r11", "memory");
+        return ret;
+}

--- a/usr/libmanticore/src/syscalls/console_print.c
+++ b/usr/libmanticore/src/syscalls/console_print.c
@@ -1,6 +1,6 @@
 #include <manticore/syscalls.h>
 
-void console_print(const char *text)
+ssize_t console_print(const char *text, size_t count)
 {
-	syscall1(SYS_console_print, (unsigned long) text);
+	return syscall2(SYS_console_print, (unsigned long) text, count);
 }

--- a/usr/tests/CMakeLists.txt
+++ b/usr/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+project(tst)
+set(CMAKE_C_FLAGS "-Wall -O3 -g -ffreestanding")
+set(CMAKE_EXE_LINKER_FLAGS "-static --entry=main -Wl,--gc-sections -nostdlib")
+add_executable(tst-console_print tst-console_print.c)
+target_link_libraries(tst-console_print manticore)
+target_link_libraries(tst-console_print linux)

--- a/usr/tests/tst-console_print.c
+++ b/usr/tests/tst-console_print.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <errno.h>
+
+#include <manticore/syscalls.h>
+
+int main(int argc, char *argv[])
+{
+	assert(console_print("hello\n", 6) == 6);
+	assert(console_print((void *)0xdeadbeef, 1) == -EFAULT);
+	assert((int)console_print((void *)0xffffffff80000000, 1) == (int)-EFAULT);
+
+	exit(0);
+}


### PR DESCRIPTION
This pull request implements a `copy_from_user()` helper, which safely copies data from user space to kernel, and change `console_print()` to use it.

Fixes #17