### PR TITLE
C runtime startup routines ("crt0")

### DIFF
--- a/usr/echod/Makefile
+++ b/usr/echod/Makefile
@@ -1,6 +1,6 @@
 PROGRAMS = echod.linux echod.manti
 
-CFLAGS = -Wall -O3 -g 
+CFLAGS = -Wall -O3 -g -static
 
 all: libs echod.linux echod.manti echod.iso
 
@@ -15,7 +15,7 @@ echod.linux: echod.c
 	gcc $(CFLAGS) echod.c -o echod.linux
 
 echod.manti: echod.c
-	gcc $(CFLAGS) -I../liblinux/include -fno-stack-protector -static -nostdlib echod.c build/liblinux/liblinux.a build/libmanticore/libmanticore.a -o echod.manti
+	gcc $(CFLAGS) -I../liblinux/include -fno-stack-protector -nostdlib echod.c build/liblinux/liblinux.a build/libmanticore/libmanticore.a -o echod.manti
 
 echod.iso: echod.manti
 	../../scripts/mkiso --kernel ../../kernel.elf --initrd echod.manti echod.iso

--- a/usr/echod/Makefile
+++ b/usr/echod/Makefile
@@ -13,7 +13,7 @@ echod.linux: echod.c
 	gcc -Wall -O3 -g echod.c -o echod.linux
 
 echod.manti: echod.c
-	gcc -Wall -O3 -g -I../liblinux/include -ffreestanding -fno-stack-protector -static --entry=main -Wl,--gc-sections -nostdlib echod.c build/liblinux/liblinux.a build/libmanticore/libmanticore.a -o echod.manti
+	gcc -Wall -O3 -g -I../liblinux/include -fno-stack-protector -static -nostdlib echod.c build/liblinux/liblinux.a build/libmanticore/libmanticore.a -o echod.manti
 
 echod.iso: echod.manti
 	../../scripts/mkiso --kernel ../../kernel.elf --initrd echod.manti echod.iso

--- a/usr/echod/Makefile
+++ b/usr/echod/Makefile
@@ -1,5 +1,7 @@
 PROGRAMS = echod.linux echod.manti
 
+CFLAGS = -Wall -O3 -g 
+
 all: libs echod.linux echod.manti echod.iso
 
 clean:
@@ -10,10 +12,10 @@ libs:
 	mkdir -p build && cd build && cmake ../.. && make
 	
 echod.linux: echod.c
-	gcc -Wall -O3 -g echod.c -o echod.linux
+	gcc $(CFLAGS) echod.c -o echod.linux
 
 echod.manti: echod.c
-	gcc -Wall -O3 -g -I../liblinux/include -fno-stack-protector -static -nostdlib echod.c build/liblinux/liblinux.a build/libmanticore/libmanticore.a -o echod.manti
+	gcc $(CFLAGS) -I../liblinux/include -fno-stack-protector -static -nostdlib echod.c build/liblinux/liblinux.a build/libmanticore/libmanticore.a -o echod.manti
 
 echod.iso: echod.manti
 	../../scripts/mkiso --kernel ../../kernel.elf --initrd echod.manti echod.iso

--- a/usr/echod/Makefile
+++ b/usr/echod/Makefile
@@ -1,6 +1,6 @@
 PROGRAMS = echod.linux echod.manti
 
-CFLAGS = -Wall -O3 -g -static
+CFLAGS = -Wall -O3 -g -static -fno-stack-protector
 
 all: libs echod.linux echod.manti echod.iso
 
@@ -15,7 +15,7 @@ echod.linux: echod.c
 	gcc $(CFLAGS) echod.c -o echod.linux
 
 echod.manti: echod.c
-	gcc $(CFLAGS) -I../liblinux/include -fno-stack-protector -nostdlib echod.c build/liblinux/liblinux.a build/libmanticore/libmanticore.a -o echod.manti
+	gcc $(CFLAGS) -I../liblinux/include -nostdlib echod.c build/liblinux/liblinux.a build/libmanticore/libmanticore.a -o echod.manti
 
 echod.iso: echod.manti
 	../../scripts/mkiso --kernel ../../kernel.elf --initrd echod.manti echod.iso

--- a/usr/liblinux/CMakeLists.txt
+++ b/usr/liblinux/CMakeLists.txt
@@ -1,8 +1,9 @@
-project(liblinux LANGUAGES C)
+project(liblinux LANGUAGES C ASM)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-stack-protector")
 
 add_library(linux
+    src/arch/x86/crt0.S
     src/arpa/inet.c
     src/epoll.c
     src/errno.c

--- a/usr/liblinux/include/stdio.h
+++ b/usr/liblinux/include/stdio.h
@@ -1,6 +1,8 @@
 #ifndef __STDIO_H
 #define __STDIO_H
 
+#include <stddef.h>
+
 struct __file {
 };
 
@@ -11,5 +13,7 @@ extern FILE *stdout;
 extern FILE *stderr;
 
 int fprintf(FILE *stream, const char *format, ...);
+
+size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
 
 #endif

--- a/usr/liblinux/src/arch/x86/crt0.S
+++ b/usr/liblinux/src/arch/x86/crt0.S
@@ -1,0 +1,12 @@
+.text
+.globl _start
+.type _start, @function
+_start:
+	xorq	%rbp, %rbp
+
+	call	main
+
+	movq	%rax, %rdi
+	call	exit
+
+	hlt

--- a/usr/liblinux/src/stdio.c
+++ b/usr/liblinux/src/stdio.c
@@ -298,7 +298,18 @@ int fprintf(FILE *stream, const char *fmt, ...)
 	int ret = vsprintf(text, fmt, ap);
 	va_end(ap);
 
+	/* FIXME: We must write to 'stream', not to console...  */
 	console_print(text, ret);
 
-	return 0; // FIXME
+	/* FIXME: Return number of characters printed.  */
+	return 0;
+}
+
+size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream)
+{
+	/* FIXME: We must write to 'stream', not to console...  */
+	console_print(ptr, size * nmemb);
+
+	/* FIXME: Return number of characters printed.  */
+	return 0;
 }


### PR DESCRIPTION
This pull request adds C runtime startup routines ("crt0") to `liblinux` and switches `usr/echod` build to use it instead of abusing the free-standing environment. We need this because invoking `main()` directly for new processes causes stack to be not aligned to 16-bytes, which breaks SSE instructions, for example.